### PR TITLE
Remove unnecessary \ from project file

### DIFF
--- a/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
+++ b/DistroLauncher-Appx/DistroLauncher-Appx.vcxproj
@@ -151,8 +151,8 @@
     <CustomBuild Include="$(targetname)">
       <FileType>Document</FileType>
       <ExcludedFromBuild>false</ExcludedFromBuild>
-      <Message>Copy $(SolutionDir)\$(platform)\$(Configuration)\launcher.exe into $(SolutionDir)\$(platform)\$(Configuration)\$(ProjectName)\$(targetname).exe</Message>
-      <Command>copy $(SolutionDir)\$(platform)\$(Configuration)\launcher.exe $(SolutionDir)\$(platform)\$(Configuration)\$(ProjectName)\$(targetname).exe</Command>
+      <Message>Copy $(SolutionDir)$(platform)\$(Configuration)\launcher.exe into $(SolutionDir)\$(platform)\$(Configuration)\$(ProjectName)\$(targetname).exe</Message>
+      <Command>copy $(SolutionDir)$(platform)\$(Configuration)\launcher.exe $(SolutionDir)\$(platform)\$(Configuration)\$(ProjectName)\$(targetname).exe</Command>
       <Outputs>$(targetname).exe</Outputs>
     </CustomBuild>
   </ItemGroup>


### PR DESCRIPTION
$(SolutionDir) already ends with a \ so no extra is needed

I know this is a minor change but it catches my eye.