### PR TITLE
Switch sample to c++17

### DIFF
--- a/DistroLauncher/DistributionInfo.h
+++ b/DistroLauncher/DistributionInfo.h
@@ -19,8 +19,8 @@ namespace DistributionInfo
     const std::wstring WindowTitle = L"My Distribution";
 
     // Create and configure a user account.
-    bool CreateUser(const std::wstring& userName);
+    bool CreateUser(std::wstring_view userName);
 
     // Query the UID of the user account.
-    ULONG QueryUid(const std::wstring& userName);
+    ULONG QueryUid(std::wstring_view userName);
 }

--- a/DistroLauncher/DistroLauncher.vcxproj
+++ b/DistroLauncher/DistroLauncher.vcxproj
@@ -74,6 +74,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/DistroLauncher/stdafx.h
+++ b/DistroLauncher/stdafx.h
@@ -22,6 +22,8 @@
 #include <assert.h>
 #include <locale>
 #include <codecvt>
+#include <string_view>
+#include <vector>
 #include <wslapi.h>
 #include "WslApiLoader.h"
 #include "Helpers.h"


### PR DESCRIPTION
This PR switches the sample to use c++17 to make use of the string view helper class to simplify argument parsing. This is in preparation for a future change to allow installing the distribution non-interactively.
