### PR TITLE
Add 'install' argument to support non-interactive install

### DIFF
--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -5,14 +5,22 @@
 
 #include "stdafx.h"
 
+// Commandline arguments: 
+#define ARG_CONFIG              L"config"
+#define ARG_CONFIG_DEFAULT_USER L"--default-user"
+#define ARG_INSTALL             L"install"
+#define ARG_INSTALL_ROOT        L"--root"
+#define ARG_RUN                 L"run"
+#define ARG_RUN_C               L"-c"
+
 // Helper class for calling WSL Functions:
 // https://msdn.microsoft.com/en-us/library/windows/desktop/mt826874(v=vs.85).aspx
 WslApiLoader g_wslApi(DistributionInfo::Name);
 
-static HRESULT InstallDistribution();
+static HRESULT InstallDistribution(bool createUser);
 static HRESULT SetDefaultUser(std::wstring_view userName);
 
-HRESULT InstallDistribution()
+HRESULT InstallDistribution(bool createUser)
 {
     // Register the distribution.
     Helpers::PrintMessage(MSG_STATUS_INSTALLING);
@@ -29,17 +37,19 @@ HRESULT InstallDistribution()
     }
 
     // Create a user account.
-    Helpers::PrintMessage(MSG_CREATE_USER_PROMPT);
-    std::wstring userName;
-    do {
-        userName = Helpers::GetUserInput(MSG_ENTER_USERNAME, 32);
+    if (createUser) {
+        Helpers::PrintMessage(MSG_CREATE_USER_PROMPT);
+        std::wstring userName;
+        do {
+            userName = Helpers::GetUserInput(MSG_ENTER_USERNAME, 32);
 
-    } while (!DistributionInfo::CreateUser(userName));
+        } while (!DistributionInfo::CreateUser(userName));
 
-    // Set this user account as the default.
-    hr = SetDefaultUser(userName);
-    if (FAILED(hr)) {
-        return hr;
+        // Set this user account as the default.
+        hr = SetDefaultUser(userName);
+        if (FAILED(hr)) {
+            return hr;
+        }
     }
 
     return hr;
@@ -85,9 +95,13 @@ int wmain(int argc, wchar_t const *argv[])
     }
 
     // Install the distribution if it is not already.
+    bool installOnly = ((arguments.size() > 0) && (arguments[0] == ARG_INSTALL));
     HRESULT hr = S_OK;
     if (!g_wslApi.WslIsDistributionRegistered()) {
-        hr = InstallDistribution();
+
+        // If the "--root" option is specified, do not create a user account.
+        bool useRoot = ((installOnly) && (arguments.size() > 1) && (arguments[1] == ARG_INSTALL_ROOT));
+        hr = InstallDistribution(!useRoot);
         if (FAILED(hr)) {
             if (hr == HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS)) {
                 Helpers::PrintMessage(MSG_INSTALL_ALREADY_EXISTS);
@@ -96,16 +110,17 @@ int wmain(int argc, wchar_t const *argv[])
         } else {
             Helpers::PrintMessage(MSG_INSTALL_SUCCESS);
         }
+
+        exitCode = SUCCEEDED(hr) ? 0 : 1;
     }
 
     // Parse the command line arguments.
-    if (SUCCEEDED(hr)) {
+    if ((SUCCEEDED(hr)) && (!installOnly)) {
         if (arguments.empty()) {
             hr = g_wslApi.WslLaunchInteractive(L"", false, &exitCode);
 
-        } else if ((arguments[0] == L"run") ||
-                   (arguments[0] == L"/c") ||
-                   (arguments[0] == L"-c")) {
+        } else if ((arguments[0] == ARG_RUN) ||
+                   (arguments[0] == ARG_RUN_C)) {
 
             std::wstring command;
             for (size_t index = 1; index < arguments.size(); index += 1) {
@@ -115,10 +130,10 @@ int wmain(int argc, wchar_t const *argv[])
 
             hr = g_wslApi.WslLaunchInteractive(command.c_str(), true, &exitCode);
 
-        } else if (arguments[0] == L"config") {
+        } else if (arguments[0] == ARG_CONFIG) {
             hr = E_INVALIDARG;
             if (arguments.size() == 3) {
-                if (arguments[1] == L"--default-user") {
+                if (arguments[1] == ARG_CONFIG_DEFAULT_USER) {
                     hr = SetDefaultUser(arguments[2]);
                 }
             }

--- a/DistroLauncher/messages.mc
+++ b/DistroLauncher/messages.mc
@@ -26,20 +26,26 @@ Launches or configures a Linux distribution.
 
 Usage: 
     <no args> 
-      - Launches the user's default shell in the user's home directory.
-    
+        Launches the user's default shell in the user's home directory.
+
+    install [option]
+        Install the distribuiton and do not launch the shell when complete.
+        Options:
+          --root
+              Do not create a user account and leave the default user set to root.
+
     run <command line> 
-      - Run the provided command line in the current working directory. If no
+        Run the provided command line in the current working directory. If no
         command line is provided, the default shell is launched.
 
     config [setting [value]] 
-      - Configure settings for this distribution.
-      - Settings are any of the following:
-        - --default-user <username>
-          Sets the default user to <username>. This must be an existing user.
-    
+        Configure settings for this distribution.
+        Settings:
+          --default-user <username>
+              Sets the default user to <username>. This must be an existing user.
+
     help 
-      - Print this usage message.
+        Print usage information.
 .
 
 MessageId=1006 SymbolicName=MSG_STATUS_INSTALLING

--- a/README.md
+++ b/README.md
@@ -14,22 +14,27 @@ This project is an active repo maintained by the WSL engineering team at Microso
 
 ### Contents
   The sample provides the following functionality:
-  (where `launcher` is replaced by the distro-specific name)
+  (where `launcher.exe` is replaced by the distro-specific name)
 
-  * `launcher`
-    - Launch the distro's default login shell.
+  * `launcher.exe`
+    - Launches the user's default shell in the user's home directory.
 
-  * `launcher run <command line>`
-    - Run the given command line in that distro, using the default configuration.
+  * `launcher.exe install [option]`
+    - Install the distribuiton and do not launch the shell when complete.
+    - Options:
+      - `--root` : Do not create a user account and leave the default user set to root.
+
+  * `launcher.exe run <command line>`
+    - Run the provided command line in the current working directory. If no command line is provided, the default shell is launched..
     - Everything after `run` is passed to WslLaunchInteractive.
 
-  * `launcher config [setting [value]]`
-    - Configure certain settings for this distro.
-    - Settings are any of the following (by default)
-      - `--default-user <username>`: Set the default user for this distro
+  * `launcher.exe config [setting [value]]`
+    - Configure settings for this distribution.
+    - Settings:
+      - `--default-user <username>`: Sets the default user to <username>. This must be an existing user.
 
-  * `launcher help`
-    - Print the usage.
+  * `launcher.exe help`
+    - Print usage information.
 
 ## Launcher Outline
   This is the basic flow of how the launcher code is set up.


### PR DESCRIPTION
This change adds a "install" argument to the sample to support registering the distribution non-interactively. This is useful because it makes the install scriptable, for example:


`mydistro.exe install --root`
