### PR TITLE
refactor QueryUid to be reusable

### DIFF
--- a/DistroLauncher/DistributionInfo.cpp
+++ b/DistroLauncher/DistributionInfo.cpp
@@ -32,7 +32,7 @@ bool DistributionInfo::CreateUser(std::wstring_view userName)
     return true;
 }
 
-ULONG DistributionInfo::QueryUid(std::wstring_view userName)
+static ULONG _QueryUid(std::wstring command)
 {
     // Create a pipe to read the output of the launched process.
     HANDLE readPipe;
@@ -40,9 +40,6 @@ ULONG DistributionInfo::QueryUid(std::wstring_view userName)
     SECURITY_ATTRIBUTES sa{sizeof(sa), nullptr, true};
     ULONG uid = UID_INVALID;
     if (CreatePipe(&readPipe, &writePipe, &sa, 0)) {
-        // Query the UID of the supplied username.
-        std::wstring command = L"/usr/bin/id -u ";
-        command += userName;
         int returnValue = 0;
         HANDLE child;
         HRESULT hr = g_wslApi.WslLaunch(command.c_str(), true, GetStdHandle(STD_INPUT_HANDLE), writePipe, GetStdHandle(STD_ERROR_HANDLE), &child);
@@ -75,4 +72,11 @@ ULONG DistributionInfo::QueryUid(std::wstring_view userName)
     }
 
     return uid;
+}
+
+ULONG DistributionInfo::QueryUid(std::wstring_view userName)
+{
+    std::wstring command = L"/usr/bin/id -u ";
+    command += userName;
+    return _QueryUid(command);
 }

--- a/DistroLauncher/DistributionInfo.h
+++ b/DistroLauncher/DistributionInfo.h
@@ -21,6 +21,6 @@ namespace DistributionInfo
     // Create and configure a user account.
     bool CreateUser(std::wstring_view userName);
 
-    // Query the UID of the user account.
+    // Query the UID of a given user account
     ULONG QueryUid(std::wstring_view userName);
 }


### PR DESCRIPTION
trying out a different approach to create the first user but still need to query it's uid afterwards. Splitting this up makes patches on top easier.