### PR TITLE
Added prompt for input when wsl.exe fails to launch Linux process

### DIFF
--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -119,6 +119,12 @@ int wmain(int argc, wchar_t const *argv[])
         if (arguments.empty()) {
             hr = g_wslApi.WslLaunchInteractive(L"", false, &exitCode);
 
+            // Check exitCode to see if wsl.exe returned that it could not start the Linux process
+            // then prompt users for input so they can view the error message.
+            if (exitCode == UINT_MAX) {
+                Helpers::PromptForInput();
+            }
+
         } else if ((arguments[0] == ARG_RUN) ||
                    (arguments[0] == ARG_RUN_C)) {
 

--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -121,7 +121,7 @@ int wmain(int argc, wchar_t const *argv[])
 
             // Check exitCode to see if wsl.exe returned that it could not start the Linux process
             // then prompt users for input so they can view the error message.
-            if (exitCode == UINT_MAX) {
+            if (SUCCEEDED(hr) && exitCode == UINT_MAX) {
                 Helpers::PromptForInput();
             }
 


### PR DESCRIPTION
This change will only affect interactive sessions run when the UWP app is launched without any arguments. 