### PR TITLE
[build.bat] place checking of VS2019 on top of the batch file.

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -2,6 +2,14 @@
 
 rem Add path to MSBuild Binaries
 set MSBUILD=()
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin\MSBuild.exe" (
+    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin\MSBuild.exe"
+    goto :FOUND_MSBUILD
+)
+if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe" (
+    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe"
+    goto :FOUND_MSBUILD
+)
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe" (
     set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\msbuild.exe"
     goto :FOUND_MSBUILD
@@ -19,19 +27,11 @@ if exist "%ProgramFiles%\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\
     goto :FOUND_MSBUILD
 )
 if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe" (
-	set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
+    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
     goto :FOUND_MSBUILD
 )
 if exist "%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe" (
-	set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin\MSBuild.exe" (
-    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Preview\MSBuild\Current\Bin\MSBuild.exe"
-    goto :FOUND_MSBUILD
-)
-if exist "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe" (
-    set MSBUILD="%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe"
+    set MSBUILD="%ProgramFiles%\Microsoft Visual Studio\2017\Enterprise\MSBuild\15.0\Bin\msbuild.exe"
     goto :FOUND_MSBUILD
 )
 if exist "%ProgramFiles(x86)%\MSBuild\14.0\bin" (


### PR DESCRIPTION
Hello.

In same way as early in this file checking of VS2017 was placed before MSBuild of .NET Framework 4.0, MSBuild of VS2019 should be placed before VS2017.
Otherwise in environments were both Studios was installed - attempt to use of non recent version will be made.

Other question is still use of VS2017 need in this project, such attempt will be got next message
```
PS WSL-DistroLauncher> .\build.bat

Build started
     1>Project "WSL-DistroLauncher\DistroLauncher.sln" on node 1 (Build target(s)).
     1>ValidateSolutionConfiguration:
         Building solution configuration "Debug|x64".
     1>Project "WSL-DistroLauncher\DistroLauncher.sln" (1) is building "WSL-DistroLauncher\DistroLauncher\DistroLauncher.vcxproj" (2) on node 1 (default targets).
     2>C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\IDE\VC\VCTargets\Microsoft.Cpp.Platform.targets(67,5): error MSB8020:
        The build tools for v142 (Platform Toolset = 'v142') cannot be found.
        To build usingthe v142 build tools, please install v142 build tools.
        Alternatively, you may upgrade to the current Visual Studio tools by selecting the Project menu or right-click the solution, and then selecting "Retarget solution".
        [WSL-DistroLauncher\DistroLauncher\DistroLauncher.vcxproj]
     2>Done Building Project "WSL-DistroLauncher\DistroLauncher\DistroLauncher.vcxproj" (default targets) -- FAILED.
     1>Done Building Project "WSL-DistroLauncher\DistroLauncher.sln" (Build target(s)) -- FAILED.

Build FAILED.

    0 Warning(s)
    1 Error(s)
```
but that moment for other discussion.

Thank you.
