### PR TITLE
WSLApiLoader exposes missing function

### DIFF
--- a/DistroLauncher/WslApiLoader.cpp
+++ b/DistroLauncher/WslApiLoader.cpp
@@ -14,6 +14,7 @@ WslApiLoader::WslApiLoader(const std::wstring& distributionName) :
         _isDistributionRegistered = (WSL_IS_DISTRIBUTION_REGISTERED)GetProcAddress(_wslApiDll, "WslIsDistributionRegistered");
         _registerDistribution = (WSL_REGISTER_DISTRIBUTION)GetProcAddress(_wslApiDll, "WslRegisterDistribution");
         _configureDistribution = (WSL_CONFIGURE_DISTRIBUTION)GetProcAddress(_wslApiDll, "WslConfigureDistribution");
+        _getDistributionConfiguration = (WSL_GET_DISTRIBUTION_CONFIGURATION)GetProcAddress(_wslApiDll, "WslGetDistributionConfiguration");
         _launchInteractive = (WSL_LAUNCH_INTERACTIVE)GetProcAddress(_wslApiDll, "WslLaunchInteractive");
         _launch = (WSL_LAUNCH)GetProcAddress(_wslApiDll, "WslLaunch");
     }
@@ -32,6 +33,7 @@ BOOL WslApiLoader::WslIsOptionalComponentInstalled()
             (_isDistributionRegistered != nullptr) &&
             (_registerDistribution != nullptr) &&
             (_configureDistribution != nullptr) &&
+            (_getDistributionConfiguration != nullptr) &&
             (_launchInteractive != nullptr) &&
             (_launch != nullptr));
 }
@@ -59,6 +61,20 @@ HRESULT WslApiLoader::WslConfigureDistribution(ULONG defaultUID, WSL_DISTRIBUTIO
     }
 
     return hr;
+}
+
+HRESULT WslApiLoader::WslGetDistributionConfiguration(ULONG* distributionVersion,
+                                                      ULONG* defaultUID,
+                                                      WSL_DISTRIBUTION_FLAGS* wslDistributionFlags, 
+                                                      PSTR** defaultEnvironmentVariables,
+                                                      ULONG* defaultEnvironmentVariableCount)
+{
+    return _getDistributionConfiguration(_distributionName.c_str(),
+                                         distributionVersion,
+                                         defaultUID,
+                                         wslDistributionFlags,
+                                         defaultEnvironmentVariables,
+                                         defaultEnvironmentVariableCount);
 }
 
 HRESULT WslApiLoader::WslLaunchInteractive(PCWSTR command, BOOL useCurrentWorkingDirectory, DWORD *exitCode)

--- a/DistroLauncher/WslApiLoader.h
+++ b/DistroLauncher/WslApiLoader.h
@@ -33,6 +33,13 @@ class WslApiLoader
     HRESULT WslConfigureDistribution(ULONG defaultUID,
                                      WSL_DISTRIBUTION_FLAGS wslDistributionFlags);
 
+    HRESULT WslGetDistributionConfiguration(ULONG* distributionVersion,
+                                            ULONG* defaultUID,
+                                            WSL_DISTRIBUTION_FLAGS* wslDistributionFlags,
+                                            PSTR** defaultEnvironmentVariables,
+                                            ULONG* defaultEnvironmentVariableCount
+                                            );
+
     HRESULT WslLaunchInteractive(PCWSTR command,
                                  BOOL useCurrentWorkingDirectory,
                                  DWORD *exitCode);
@@ -50,6 +57,7 @@ class WslApiLoader
     WSL_IS_DISTRIBUTION_REGISTERED _isDistributionRegistered;
     WSL_REGISTER_DISTRIBUTION _registerDistribution;
     WSL_CONFIGURE_DISTRIBUTION _configureDistribution;
+    WSL_GET_DISTRIBUTION_CONFIGURATION _getDistributionConfiguration;
     WSL_LAUNCH_INTERACTIVE _launchInteractive;
     WSL_LAUNCH _launch;
 };


### PR DESCRIPTION
While working on Ubuntu launcher we felt the needf for the function WslGetDistributionConfiguration() to take decisions based on the subsystem environment of the registered distro. That function is not currently exposed in the WslApiLoader class.

Closes #96 .