### PR TITLE
Change WSL to use system error string for WSL OC not present

### DIFF
--- a/DistroLauncher/DistroLauncher.cpp
+++ b/DistroLauncher/DistroLauncher.cpp
@@ -86,7 +86,7 @@ int wmain(int argc, wchar_t const *argv[])
     // Ensure that the Windows Subsystem for Linux optional component is installed.
     DWORD exitCode = 1;
     if (!g_wslApi.WslIsOptionalComponentInstalled()) {
-        Helpers::PrintMessage(MSG_MISSING_OPTIONAL_COMPONENT);
+        Helpers::PrintErrorMessage(HRESULT_FROM_WIN32(ERROR_LINUX_SUBSYSTEM_NOT_PRESENT));
         if (arguments.empty()) {
             Helpers::PromptForInput();
         }
@@ -156,10 +156,7 @@ int wmain(int argc, wchar_t const *argv[])
 
     // If an error was encountered, print an error message.
     if (FAILED(hr)) {
-        if (hr == HRESULT_FROM_WIN32(ERROR_LINUX_SUBSYSTEM_NOT_PRESENT)) {
-            Helpers::PrintMessage(MSG_MISSING_OPTIONAL_COMPONENT);
-
-        } else if (hr == HCS_E_HYPERV_NOT_INSTALLED) {
+        if (hr == HCS_E_HYPERV_NOT_INSTALLED) {
             Helpers::PrintMessage(MSG_ENABLE_VIRTUALIZATION);
 
         } else {

--- a/DistroLauncher/messages.mc
+++ b/DistroLauncher/messages.mc
@@ -78,12 +78,6 @@ Language=English
 Press any key to continue...
 .
 
-MessageId=1012 SymbolicName=MSG_MISSING_OPTIONAL_COMPONENT
-Language=English
-The Windows Subsystem for Linux optional component is not enabled. Please enable it and try again.
-See https://aka.ms/wslinstall for details.
-.
-
 MessageId=1013 SymbolicName=MSG_INSTALL_ALREADY_EXISTS
 Language=English
 The distribution installation has become corrupted.


### PR DESCRIPTION
This change moves the sample to the inbox error message for when WSL is not installed.